### PR TITLE
using init container to ensure mongo pod is ready before deploying lab partner

### DIFF
--- a/charts/lab-partner/templates/deployment.yaml
+++ b/charts/lab-partner/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
       serviceAccountName: {{ include "lab-partner.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-for-mongodb
+          image: bitnami/kubectl:1.15
+          args: ['wait','--for=condition=ready','pod', '-l app=mongodb','--timeout=300s']
       containers:
         - name: lab-partner
           securityContext:

--- a/charts/lab-partner/templates/role.yaml
+++ b/charts/lab-partner/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.serviceAccount.name }}-role
+  labels:
+    app.kubernetes.io/name: {{ .Values.serviceAccount.name }}-role
+    app.kubernetes.io/component: lab-partner 
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: helm
+  annotations:
+    description: Role granting permissions for lab-partner
+    source-repo: https://github.com/liatrio/lab-partner
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+{{- end -}}

--- a/charts/lab-partner/templates/rolebinding.yaml
+++ b/charts/lab-partner/templates/rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Values.serviceAccount.name }}-binding"
+  labels:
+    app.kubernetes.io/name: "{{ .Values.serviceAccount.name }}-binding"
+    app.kubernetes.io/component: lab-partner
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: helm
+  annotations:
+    description: Binds the lab-parter role to the lab-partner svc account
+    source-repo: https://github.com/liatrio/lab-partner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.serviceAccount.name }}-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ $.Release.Namespace }}
+{{- end -}}

--- a/charts/lab-partner/templates/serviceaccount.yaml
+++ b/charts/lab-partner/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "lab-partner.serviceAccountName" . }}
+  name: {{ .Values.serviceAccount.name }}
   labels:
     {{- include "lab-partner.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/lab-partner/values.yaml
+++ b/charts/lab-partner/values.yaml
@@ -13,6 +13,9 @@ mongodb:
       username: lab-partner
       database: lab-partner
       password:
+  podLabels:
+    app: mongodb
+  #useStatefulSet: true
 
 image: 
   name: liatrio/lab-partner
@@ -30,7 +33,7 @@ fullnameOverride: ""
 serviceAccount:
   create: true
   annotations: {}
-  name:
+  name: lab-partner
 
 podSecurityContext: {}
 

--- a/charts/lab-partner/values.yaml
+++ b/charts/lab-partner/values.yaml
@@ -15,7 +15,6 @@ mongodb:
       password:
   podLabels:
     app: mongodb
-  #useStatefulSet: true
 
 image: 
   name: liatrio/lab-partner


### PR DESCRIPTION
Need to create service account to be able to watch and list pods for init container to wait for mongo pod to bed ready before deploying lab-partner