### PR TITLE
ci: update gitops manifest path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,5 @@ jobs:
         url: https://github.com/liatrio/lead-environments.git
         username: ${{ github.actor }}
         password: ${{ secrets.GITTY_UP_TOKEN }}
-        file: aws/manifest.yml
-        values: liatrio_sandbox.lab_partner_version=${{steps.gitextra.outputs.version}}
-    
+        file: aws/liatrio-sandbox/manifest.yml
+        values: lab_partner_version=${{steps.gitextra.outputs.version}}


### PR DESCRIPTION
The location and layout of the manifest changed in https://github.com/liatrio/lead-environments/pull/608